### PR TITLE
"logging collector"の訳語を「ログ収集機構」に変更

### DIFF
--- a/jpug-doc.en.ja.csv
+++ b/jpug-doc.en.ja.csv
@@ -1615,7 +1615,7 @@ log,ログ
 log-file manager,ログファイルマネージャ
 log-shipping standby server,ログシッピングスタンバイサーバ
 logged into,ログオン
-logging collector,logging collector
+logging collector,ログ収集機構
 logging options,ロギングオプション
 logging parameters,ロギングパラメータ
 logging,ロギング


### PR DESCRIPTION
[jpug-doc:5346]で提起した件です。
翻訳自体はjpug-docのPR900で訳語統一を図っています。