### PR TITLE
localeの翻訳を「照合」から「照合順序」に変更

### DIFF
--- a/jpug-doc.en.ja.csv
+++ b/jpug-doc.en.ja.csv
@@ -495,7 +495,7 @@ code,コード
 coding conventions,コーディング規約
 coding,コーディング
 collation derivation,照合の導出
-collation,照合
+collation,照合順序
 collection of tables,テーブルの（そしてテーブルだけからなる）集合
 collector process,コレクタプロセス
 collector,コレクタ


### PR DESCRIPTION
[jpug-doc: 5571]による。